### PR TITLE
refactor(api): remove wrapper object from BrowseApi interface

### DIFF
--- a/src/main/java/spotify/api/impl/BrowseApiRetrofit.java
+++ b/src/main/java/spotify/api/impl/BrowseApiRetrofit.java
@@ -6,12 +6,17 @@ import retrofit2.Call;
 import retrofit2.Response;
 import spotify.api.enums.HttpStatusCode;
 import spotify.api.interfaces.BrowseApi;
+import spotify.exceptions.ExceptionMessages;
 import spotify.exceptions.HttpRequestFailedException;
+import spotify.exceptions.SpotifyActionFailedException;
 import spotify.factories.RetrofitHttpServiceFactory;
+import spotify.models.albums.AlbumSimplified;
 import spotify.models.albums.AlbumSimplifiedPaging;
 import spotify.models.categories.CategoryFull;
 import spotify.models.categories.CategoryFullPaging;
+import spotify.models.paging.Paging;
 import spotify.models.playlists.FeaturedPlaylistCollection;
+import spotify.models.playlists.PlaylistSimplified;
 import spotify.models.playlists.PlaylistSimplifiedPaging;
 import spotify.models.recommendations.RecommendationCollection;
 import spotify.retrofit.services.BrowseService;
@@ -60,8 +65,20 @@ public class BrowseApiRetrofit implements BrowseApi {
         }
     }
 
+    /**
+     * @deprecated Replaced by {@link #getCategoryPlaylistsPaging(String, Map)} in version 1.5.8.
+     */
     @Override
+    @Deprecated(since = "1.5.8")
     public PlaylistSimplifiedPaging getCategoryPlaylists(String categoryId, Map<String, String> options) {
+        Paging<PlaylistSimplified> categoryFullPaging = getCategoryPlaylistsPaging(categoryId, options);
+        PlaylistSimplifiedPaging output = new PlaylistSimplifiedPaging();
+        output.setPlaylists(categoryFullPaging);
+        return output;
+    }
+    
+    @Override
+    public Paging<PlaylistSimplified> getCategoryPlaylistsPaging(String categoryId, Map<String, String> options) {
         options = ValidatorUtil.optionsValueCheck(options);
 
         logger.trace("Constructing HTTP call to fetch category playlists.");
@@ -75,16 +92,31 @@ public class BrowseApiRetrofit implements BrowseApi {
 
             ResponseChecker.throwIfRequestHasNotBeenFulfilledCorrectly(response, HttpStatusCode.OK);
 
+            if (response.body() == null) {
+                throw new SpotifyActionFailedException(ExceptionMessages.EMPTY_RESPONSE_BODY);
+            }
             logger.info("Category playlists have been successfully fetched.");
-            return response.body();
+            return response.body().getPlaylists();
         } catch (IOException ex) {
             logger.error("HTTP request to fetch category playlists has failed.");
             throw new HttpRequestFailedException(ex.getMessage());
         }
     }
 
+    /**
+     * @deprecated Replaced by {@link #getCategoriesPaging(Map)} in version 1.5.8.
+     */
     @Override
+    @Deprecated(since = "1.5.8")
     public CategoryFullPaging getCategories(Map<String, String> options) {
+        Paging<CategoryFull> categoryFullPaging = getCategoriesPaging(options);
+        CategoryFullPaging output = new CategoryFullPaging();
+        output.setCategories(categoryFullPaging);
+        return output;
+    }
+    
+    @Override
+    public Paging<CategoryFull> getCategoriesPaging(Map<String, String> options) {
         options = ValidatorUtil.optionsValueCheck(options);
 
         logger.trace("Constructing HTTP call to fetch categories.");
@@ -98,8 +130,12 @@ public class BrowseApiRetrofit implements BrowseApi {
 
             ResponseChecker.throwIfRequestHasNotBeenFulfilledCorrectly(response, HttpStatusCode.OK);
 
+            if (response.body() == null) {
+                throw new SpotifyActionFailedException(ExceptionMessages.EMPTY_RESPONSE_BODY);
+            }
+            
             logger.info("Categories have been successfully fetched.");
-            return response.body();
+            return response.body().getCategories();
         } catch (IOException ex) {
             logger.error("HTTP request to fetch categories has failed.");
             throw new HttpRequestFailedException(ex.getMessage());
@@ -129,8 +165,19 @@ public class BrowseApiRetrofit implements BrowseApi {
         }
     }
 
+    /**
+     * @deprecated Replaced by {@link #getNewReleasesPaging(Map)} in version 1.5.8.
+     */
     @Override
     public AlbumSimplifiedPaging getNewReleases(Map<String, String> options) {
+        Paging<AlbumSimplified> albumSimplifiedPaging = getNewReleasesPaging(options);
+        AlbumSimplifiedPaging output = new AlbumSimplifiedPaging();
+        output.setAlbums(albumSimplifiedPaging);
+        return output;
+    }
+    
+    @Override
+    public Paging<AlbumSimplified> getNewReleasesPaging(Map<String, String> options) {
         options = ValidatorUtil.optionsValueCheck(options);
 
         logger.trace("Constructing HTTP call to fetch new releases.");
@@ -144,8 +191,12 @@ public class BrowseApiRetrofit implements BrowseApi {
 
             ResponseChecker.throwIfRequestHasNotBeenFulfilledCorrectly(response, HttpStatusCode.OK);
 
+            if (response.body() == null) {
+                throw new SpotifyActionFailedException(ExceptionMessages.EMPTY_RESPONSE_BODY);
+            }
+            
             logger.info("New releases have been successfully fetched.");
-            return response.body();
+            return response.body().getAlbums();
         } catch (IOException ex) {
             logger.error("HTTP request to fetch new releases has failed.");
             throw new HttpRequestFailedException(ex.getMessage());

--- a/src/main/java/spotify/api/impl/FollowApiRetrofit.java
+++ b/src/main/java/spotify/api/impl/FollowApiRetrofit.java
@@ -7,6 +7,7 @@ import retrofit2.Response;
 import spotify.api.enums.EntityType;
 import spotify.api.enums.HttpStatusCode;
 import spotify.api.interfaces.FollowApi;
+import spotify.exceptions.ExceptionMessages;
 import spotify.exceptions.HttpRequestFailedException;
 import spotify.exceptions.SpotifyActionFailedException;
 import spotify.factories.RetrofitHttpServiceFactory;
@@ -145,7 +146,7 @@ public class FollowApiRetrofit implements FollowApi {
                 return response.body().getArtists();
             }
 
-            final String errorMessage = "Empty response body has been returned. Reason is unknown";
+            final String errorMessage = ExceptionMessages.EMPTY_RESPONSE_BODY;
 
             logger.error(errorMessage);
             throw new SpotifyActionFailedException(errorMessage);

--- a/src/main/java/spotify/api/interfaces/BrowseApi.java
+++ b/src/main/java/spotify/api/interfaces/BrowseApi.java
@@ -1,9 +1,12 @@
 package spotify.api.interfaces;
 
+import spotify.models.albums.AlbumSimplified;
 import spotify.models.albums.AlbumSimplifiedPaging;
 import spotify.models.categories.CategoryFull;
 import spotify.models.categories.CategoryFullPaging;
+import spotify.models.paging.Paging;
 import spotify.models.playlists.FeaturedPlaylistCollection;
+import spotify.models.playlists.PlaylistSimplified;
 import spotify.models.playlists.PlaylistSimplifiedPaging;
 import spotify.models.recommendations.RecommendationCollection;
 
@@ -13,13 +16,31 @@ import java.util.Map;
 public interface BrowseApi {
     CategoryFull getCategory(String categoryId, Map<String, String> options);
 
+    /**
+     * @deprecated Replaced by {@link #getCategoryPlaylistsPaging(String, Map)} in version 1.5.8.
+     */
+    @Deprecated(since = "1.5.8")
     PlaylistSimplifiedPaging getCategoryPlaylists(String categoryId, Map<String, String> options);
 
+    Paging<PlaylistSimplified> getCategoryPlaylistsPaging(String categoryId, Map<String, String> options);
+
+    /**
+     * @deprecated Replaced by {@link #getCategoriesPaging(Map)} in version 1.5.8.
+     */
+    @Deprecated(since = "1.5.8")
     CategoryFullPaging getCategories(Map<String, String> options);
+    
+    Paging<CategoryFull> getCategoriesPaging(Map<String, String> options);
 
     FeaturedPlaylistCollection getFeaturedPlaylists(Map<String, String> options);
 
+    /**
+     * @deprecated Replaced by {@link #getNewReleasesPaging(Map)} in version 1.5.8.
+     */
+    @Deprecated(since = "1.5.8")
     AlbumSimplifiedPaging getNewReleases(Map<String, String> options);
 
+    Paging<AlbumSimplified> getNewReleasesPaging(Map<String, String> options);
+    
     RecommendationCollection getRecommendations(List<String> listOfSeedArtists, List<String> listOfSeedGenres, List<String> listOfSeedTracks, Map<String, String> options);
 }

--- a/src/main/java/spotify/api/spotify/SpotifyApi.java
+++ b/src/main/java/spotify/api/spotify/SpotifyApi.java
@@ -178,14 +178,32 @@ public class SpotifyApi {
         return browseApi.getCategory(categoryId, options);
     }
 
+    /**
+     * @deprecated Replaced by {@link #getCategoryPlaylistsPaging(String, Map)} in 1.5.8.
+     */
+    @Deprecated(since = "1.5.8")
     public PlaylistSimplifiedPaging getCategoryPlaylists(String categoryId, Map<String, String> options) {
         logger.info("Requesting category playlists");
         return browseApi.getCategoryPlaylists(categoryId, options);
     }
+    
+    public Paging<PlaylistSimplified> getCategoryPlaylistsPaging(String categoryId, Map<String, String> options) {
+        logger.info("Requesting category playlists");
+        return browseApi.getCategoryPlaylistsPaging(categoryId, options);
+    }
 
+    /**
+     * @deprecated Replaced by {@link #getCategoriesPaging(Map)} in 1.5.8.
+     */
+    @Deprecated(since = "1.5.8")
     public CategoryFullPaging getCategories(Map<String, String> options) {
         logger.info("Requesting categories");
         return browseApi.getCategories(options);
+    }
+    
+    public Paging<CategoryFull> getCategoriesPaging(Map<String, String> options) {
+        logger.info("Requesting categories");
+        return browseApi.getCategoriesPaging(options);
     }
 
     public FeaturedPlaylistCollection getFeaturedPlaylists(Map<String, String> options) {
@@ -193,9 +211,18 @@ public class SpotifyApi {
         return browseApi.getFeaturedPlaylists(options);
     }
 
+    /**
+     * @deprecated Replaced by {@link #getNewReleasesPaging(Map)} in 1.5.8.
+     */
+    @Deprecated(since = "1.5.8")
     public AlbumSimplifiedPaging getNewReleases(Map<String, String> options) {
         logger.info("Requesting new releases");
         return browseApi.getNewReleases(options);
+    }
+    
+    public Paging<AlbumSimplified> getNewReleasesPaging(Map<String, String> options) {
+        logger.info("Requesting new releases");
+        return browseApi.getNewReleasesPaging(options);
     }
 
     public RecommendationCollection getRecommendations(List<String> listOfSeedArtists, List<String> listOfSeedGenres, List<String> listOfSeedTracks, Map<String, String> options) {

--- a/src/main/java/spotify/exceptions/ExceptionMessages.java
+++ b/src/main/java/spotify/exceptions/ExceptionMessages.java
@@ -1,0 +1,6 @@
+package spotify.exceptions;
+
+public class ExceptionMessages {
+
+    public static final String EMPTY_RESPONSE_BODY = "Empty response body has been returned. Reason is unknown";
+}

--- a/src/test/java/spotify/api/impl/BrowseApiRetrofitTest.java
+++ b/src/test/java/spotify/api/impl/BrowseApiRetrofitTest.java
@@ -15,6 +15,7 @@ import spotify.exceptions.SpotifyActionFailedException;
 import spotify.models.albums.AlbumSimplifiedPaging;
 import spotify.models.categories.CategoryFull;
 import spotify.models.categories.CategoryFullPaging;
+import spotify.models.paging.Paging;
 import spotify.models.playlists.FeaturedPlaylistCollection;
 import spotify.models.playlists.PlaylistSimplifiedPaging;
 import spotify.models.recommendations.RecommendationCollection;
@@ -127,24 +128,43 @@ public class BrowseApiRetrofitTest extends AbstractApiRetrofitTest {
         Assertions.assertNotNull(sut.getCategory(fakeCategoryId, fakeOptionalParameters));
     }
 
-    @Test
+    @Test @Deprecated(since = "1.5.8")
     void getCategoriesUsesCorrectValuesToCreateHttpCall() throws IOException {
-        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(new CategoryFullPaging()));
+        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(createCategoryFullPaging()));
 
         sut.getCategories(null);
 
         verify(mockedBrowseService).getCategories(fakeAccessTokenWithBearer, fakeOptionalParameters);
     }
-
+    
     @Test
+    void getCategoriesPagingUsesCorrectValuesToCreateHttpCall() throws IOException {
+        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(createCategoryFullPaging()));
+
+        sut.getCategoriesPaging(null);
+
+        verify(mockedBrowseService).getCategories(fakeAccessTokenWithBearer, fakeOptionalParameters);
+    }
+    
+    @Test @Deprecated(since = "1.5.8")
     void getCategoriesExecutesHttpCall() throws IOException {
-        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(new CategoryFullPaging()));
+        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(createCategoryFullPaging()));
 
         sut.getCategories(fakeOptionalParameters);
         verify(mockedCategoryFullPagingCall).execute();
     }
-
+    
     @Test
+    void getCategoriesPagingExecutesHttpCall() throws IOException {
+        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(createCategoryFullPaging()));
+
+        sut.getCategoriesPaging(fakeOptionalParameters);
+        verify(mockedCategoryFullPagingCall).execute();
+    }
+
+
+    
+    @Test @Deprecated(since = "1.5.8") @SuppressWarnings("deprecation")
     void getCategoriesThrowsSpotifyActionFailedExceptionWhenError() throws IOException {
         when(mockedCategoryFullPagingCall.execute())
                 .thenReturn(
@@ -156,39 +176,83 @@ public class BrowseApiRetrofitTest extends AbstractApiRetrofitTest {
 
         Assertions.assertThrows(SpotifyActionFailedException.class, () -> sut.getCategories(fakeOptionalParameters));
     }
-
+    
     @Test
+    void getCategoriesPagingThrowsSpotifyActionFailedExceptionWhenError() throws IOException {
+        when(mockedCategoryFullPagingCall.execute())
+                .thenReturn(
+                        Response.error(
+                                400,
+                                ResponseBody.create(MediaType.get("application/json"), getJson("error.json"))
+                        )
+                );
+
+        Assertions.assertThrows(SpotifyActionFailedException.class, () -> sut.getCategoriesPaging(fakeOptionalParameters));
+    }
+
+    @Test @Deprecated(since = "1.5.8") @SuppressWarnings("deprecation")
     void getCategoriesThrowsHttpRequestFailedWhenHttpFails() throws IOException {
         when(mockedCategoryFullPagingCall.execute()).thenThrow(IOException.class);
 
         Assertions.assertThrows(HttpRequestFailedException.class, () -> sut.getCategories(fakeOptionalParameters));
     }
-
+    
     @Test
+    void getCategoriesPagingThrowsHttpRequestFailedWhenHttpFails() throws IOException {
+        when(mockedCategoryFullPagingCall.execute()).thenThrow(IOException.class);
+
+        Assertions.assertThrows(HttpRequestFailedException.class, () -> sut.getCategoriesPaging(fakeOptionalParameters));
+    }
+
+    @Test @Deprecated(since = "1.5.8")
     void getCategoriesReturnsCategoryFullPagingWhenSuccessful() throws IOException {
-        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(new CategoryFullPaging()));
+        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(createCategoryFullPaging()));
 
         Assertions.assertNotNull(sut.getCategories(fakeOptionalParameters));
     }
+    
+    @Test 
+    void getCategoriesPagingReturnsCategoryFullPagingWhenSuccessful() throws IOException {
+        when(mockedCategoryFullPagingCall.execute()).thenReturn(Response.success(createCategoryFullPaging()));
 
-    @Test
+        Assertions.assertNotNull(sut.getCategoriesPaging(fakeOptionalParameters));
+    }
+
+    @Test @Deprecated(since = "1.5.8")
     void getCategoryPlaylistsUsesCorrectValuesToCreateHttpCall() throws IOException {
-        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(new PlaylistSimplifiedPaging()));
+        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(createPlaylistSimplifiedPaging()));
 
         sut.getCategoryPlaylists(fakeCategoryId, null);
 
         verify(mockedBrowseService).getCategoryPlaylists(fakeAccessTokenWithBearer, fakeCategoryId, fakeOptionalParameters);
     }
-
+    
     @Test
+    void getCategoryPlaylistsPagingUsesCorrectValuesToCreateHttpCall() throws IOException {
+        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(createPlaylistSimplifiedPaging()));
+
+        sut.getCategoryPlaylistsPaging(fakeCategoryId, null);
+
+        verify(mockedBrowseService).getCategoryPlaylists(fakeAccessTokenWithBearer, fakeCategoryId, fakeOptionalParameters);
+    }
+
+    @Test @Deprecated(since = "1.5.8")
     void getCategoryPlaylistsExecutesHttpCall() throws IOException {
-        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(new PlaylistSimplifiedPaging()));
+        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(createPlaylistSimplifiedPaging()));
 
         sut.getCategoryPlaylists(fakeCategoryId, fakeOptionalParameters);
         verify(mockedPlaylistSimplifiedPagingCall).execute();
     }
-
+    
     @Test
+    void getCategoryPlaylistsPagingExecutesHttpCall() throws IOException {
+        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(createPlaylistSimplifiedPaging()));
+
+        sut.getCategoryPlaylistsPaging(fakeCategoryId, fakeOptionalParameters);
+        verify(mockedPlaylistSimplifiedPagingCall).execute();
+    }
+
+    @Test @Deprecated(since = "1.5.8") @SuppressWarnings("deprecation")
     void getCategoryPlaylistsThrowsSpotifyActionFailedExceptionWhenError() throws IOException {
         when(mockedPlaylistSimplifiedPagingCall.execute())
                 .thenReturn(
@@ -202,17 +266,44 @@ public class BrowseApiRetrofitTest extends AbstractApiRetrofitTest {
     }
 
     @Test
+    void getCategoryPlaylistsPagingThrowsSpotifyActionFailedExceptionWhenError() throws IOException {
+        when(mockedPlaylistSimplifiedPagingCall.execute())
+                .thenReturn(
+                        Response.error(
+                                400,
+                                ResponseBody.create(MediaType.get("application/json"), getJson("error.json"))
+                        )
+                );
+
+        Assertions.assertThrows(SpotifyActionFailedException.class, () -> sut.getCategoryPlaylistsPaging(fakeCategoryId, fakeOptionalParameters));
+    }
+
+    @Test @Deprecated(since = "1.5.8") @SuppressWarnings("deprecation")
     void getCategoryPlaylistsThrowsHttpRequestFailedWhenHttpFails() throws IOException {
         when(mockedPlaylistSimplifiedPagingCall.execute()).thenThrow(IOException.class);
 
         Assertions.assertThrows(HttpRequestFailedException.class, () -> sut.getCategoryPlaylists(fakeCategoryId, fakeOptionalParameters));
     }
-
+    
     @Test
+    void getCategoryPlaylistsPagingThrowsHttpRequestFailedWhenHttpFails() throws IOException {
+        when(mockedPlaylistSimplifiedPagingCall.execute()).thenThrow(IOException.class);
+
+        Assertions.assertThrows(HttpRequestFailedException.class, () -> sut.getCategoryPlaylistsPaging(fakeCategoryId, fakeOptionalParameters));
+    }
+
+    @Test @Deprecated(since = "1.5.8")
     void getCategoryPlaylistsReturnsPlaylistSimplifiedPagingWhenSuccessful() throws IOException {
-        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(new PlaylistSimplifiedPaging()));
+        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(createPlaylistSimplifiedPaging()));
 
         Assertions.assertNotNull(sut.getCategoryPlaylists(fakeCategoryId, fakeOptionalParameters));
+    }
+    
+    @Test
+    void getCategoryPlaylistsPagingReturnsPlaylistSimplifiedPagingWhenSuccessful() throws IOException {
+        when(mockedPlaylistSimplifiedPagingCall.execute()).thenReturn(Response.success(createPlaylistSimplifiedPaging()));
+
+        Assertions.assertNotNull(sut.getCategoryPlaylistsPaging(fakeCategoryId, fakeOptionalParameters));
     }
 
     @Test
@@ -259,24 +350,41 @@ public class BrowseApiRetrofitTest extends AbstractApiRetrofitTest {
         Assertions.assertNotNull(sut.getFeaturedPlaylists(fakeOptionalParameters));
     }
 
-    @Test
+    @Test @Deprecated(since = "1.5.8")
     void getNewReleasesUsesCorrectValuesToCreateHttpCall() throws IOException {
-        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(new AlbumSimplifiedPaging()));
+        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(createAlbumSimplifiedPaging()));
 
         sut.getNewReleases(null);
 
         verify(mockedBrowseService).getNewReleases(fakeAccessTokenWithBearer, fakeOptionalParameters);
     }
-
+    
     @Test
+    void getNewReleasesPagingUsesCorrectValuesToCreateHttpCall() throws IOException {
+        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(createAlbumSimplifiedPaging()));
+
+        sut.getNewReleasesPaging(null);
+
+        verify(mockedBrowseService).getNewReleases(fakeAccessTokenWithBearer, fakeOptionalParameters);
+    }
+
+    @Test @Deprecated(since = "1.5.8")
     void getNewReleasesExecutesHttpCall() throws IOException {
-        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(new AlbumSimplifiedPaging()));
+        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(createAlbumSimplifiedPaging()));
 
         sut.getNewReleases(fakeOptionalParameters);
         verify(mockedAlbumSimplifiedPagingCall).execute();
     }
-
+    
     @Test
+    void getNewReleasesPagingExecutesHttpCall() throws IOException {
+        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(createAlbumSimplifiedPaging()));
+
+        sut.getNewReleasesPaging(fakeOptionalParameters);
+        verify(mockedAlbumSimplifiedPagingCall).execute();
+    }
+
+    @Test @Deprecated(since = "1.5.8") @SuppressWarnings("deprecation")
     void getNewReleasesThrowsSpotifyActionFailedExceptionWhenError() throws IOException {
         when(mockedAlbumSimplifiedPagingCall.execute())
                 .thenReturn(
@@ -288,19 +396,46 @@ public class BrowseApiRetrofitTest extends AbstractApiRetrofitTest {
 
         Assertions.assertThrows(SpotifyActionFailedException.class, () -> sut.getNewReleases(fakeOptionalParameters));
     }
-
+    
     @Test
+    void getNewReleasesPagingThrowsSpotifyActionFailedExceptionWhenError() throws IOException {
+        when(mockedAlbumSimplifiedPagingCall.execute())
+                .thenReturn(
+                        Response.error(
+                                400,
+                                ResponseBody.create(MediaType.get("application/json"), getJson("error.json"))
+                        )
+                );
+
+        Assertions.assertThrows(SpotifyActionFailedException.class, () -> sut.getNewReleasesPaging(fakeOptionalParameters));
+    }
+
+    @Test @Deprecated(since = "1.5.8") @SuppressWarnings("deprecation")
     void getNewReleasesThrowsHttpRequestFailedWhenHttpFails() throws IOException {
         when(mockedAlbumSimplifiedPagingCall.execute()).thenThrow(IOException.class);
 
         Assertions.assertThrows(HttpRequestFailedException.class, () -> sut.getNewReleases(fakeOptionalParameters));
     }
-
+    
     @Test
+    void getNewReleasesPagingThrowsHttpRequestFailedWhenHttpFails() throws IOException {
+        when(mockedAlbumSimplifiedPagingCall.execute()).thenThrow(IOException.class);
+
+        Assertions.assertThrows(HttpRequestFailedException.class, () -> sut.getNewReleasesPaging(fakeOptionalParameters));
+    }
+
+    @Test@Deprecated(since = "1.5.8")
     void getNewReleasesReturnsAlbumSimplifiedPagingWhenSuccessful() throws IOException {
-        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(new AlbumSimplifiedPaging()));
+        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(createAlbumSimplifiedPaging()));
 
         Assertions.assertNotNull(sut.getNewReleases(fakeOptionalParameters));
+    }
+    
+    @Test
+    void getNewReleasesPagingReturnsAlbumSimplifiedPagingWhenSuccessful() throws IOException {
+        when(mockedAlbumSimplifiedPagingCall.execute()).thenReturn(Response.success(createAlbumSimplifiedPaging()));
+
+        Assertions.assertNotNull(sut.getNewReleasesPaging(fakeOptionalParameters));
     }
 
     @Test
@@ -375,4 +510,23 @@ public class BrowseApiRetrofitTest extends AbstractApiRetrofitTest {
         verify(mockedOptionalParametersWithSeeds).put("seed_genres", fakeSeedGenres);
         verify(mockedOptionalParametersWithSeeds).put("seed_tracks", fakeSeedTracks);
     }
+    
+    private AlbumSimplifiedPaging createAlbumSimplifiedPaging() {
+        AlbumSimplifiedPaging albumSimplifiedPaging = new AlbumSimplifiedPaging();
+        albumSimplifiedPaging.setAlbums(new Paging<>());
+        return albumSimplifiedPaging;
+    }
+
+    private PlaylistSimplifiedPaging createPlaylistSimplifiedPaging() {
+        PlaylistSimplifiedPaging playlistSimplifiedPaging = new PlaylistSimplifiedPaging();
+        playlistSimplifiedPaging.setPlaylists(new Paging<>());
+        return playlistSimplifiedPaging;
+    }
+    
+    private CategoryFullPaging createCategoryFullPaging() {
+        CategoryFullPaging categoryFullPaging = new CategoryFullPaging();
+        categoryFullPaging.setCategories(new Paging<>());
+        return categoryFullPaging;
+    }
+
 }


### PR DESCRIPTION
# Description

According to #9, BrowseApi#getCategoryPlaylists, BrowseApi#getCategories and BrowseApi#getNewReleases now directly return the Paging<> objects, skipping the internal classes PlaylistSimplifiedPaging etc.

The old interface was preserved and marked as deprecated. 

Side effects: If the response body returned by the http call is null, now a SpotifyActionFailedException is thrown. 

Reading this, I'm noticing that's something I should fix immediately. 

Fixes #9 

## Type of change

- [x] Refactoring measure
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] All unit tests for the old interface are also applyed to the new interface
- [x] included new unit tests that validate that the exceptions on empty returned body are thrown correctly

# Checklist:

- [x] My code follows the (style) guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules